### PR TITLE
updated gorilla/schema & go-playground/form tests to be used as indicated in README's

### DIFF
--- a/formam_1_test.go
+++ b/formam_1_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/ajg/form"
-	"github.com/monoculum/formam"
 	formm "github.com/go-playground/form"
+	"github.com/monoculum/formam"
 )
 
 type Anonymous struct {
@@ -63,12 +63,12 @@ var (
 	valuesFormT1 = url.Values{
 		"Nest.Children[0].Id":   []string{"monoculum_id"},
 		"Nest.Children[0].Name": []string{"Monoculum"},
-		"Map[es_Es][0]":          []string{"javier"},
-		"Map[es_Es][1]":          []string{"javier"},
-		"Map[es_Es][2]":          []string{"javier"},
-		"Map[es_Es][3]":          []string{"javier"},
-		"Map[es_Es][4]":          []string{"javier"},
-		"Map[es_Es][5]":          []string{"javier"},
+		"Map[es_Es][0]":         []string{"javier"},
+		"Map[es_Es][1]":         []string{"javier"},
+		"Map[es_Es][2]":         []string{"javier"},
+		"Map[es_Es][3]":         []string{"javier"},
+		"Map[es_Es][4]":         []string{"javier"},
+		"Map[es_Es][5]":         []string{"javier"},
 		"string":                []string{"golang is very fun"},
 		"Slice[0]":              []string{"1"},
 		"Slice[1]":              []string{"2"},
@@ -126,10 +126,12 @@ func BenchmarkFormamTest1(b *testing.B) {
 }
 
 func BenchmarkFormTest1(b *testing.B) {
+
+	decoder := formm.NewDecoder()
+
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		test := new(Bench)
-		decoder := formm.NewDecoder()
 		if err := decoder.Decode(test, valuesFormT1); err != nil {
 			b.Error(err)
 		}

--- a/formam_2_test.go
+++ b/formam_2_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/ajg/form"
+	formm "github.com/go-playground/form"
 	"github.com/gorilla/schema"
 	"github.com/monoculum/formam"
-	formm "github.com/go-playground/form"
 )
 
 type BenchFormamSchema struct {
@@ -85,10 +85,12 @@ func BenchmarkAJGFormTest2(b *testing.B) {
 }
 
 func BenchmarkSchemaTest2(b *testing.B) {
+
+	dec := schema.NewDecoder()
+
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		ne := new(BenchFormamSchema)
-		dec := schema.NewDecoder()
 		if err := dec.Decode(ne, valSchemaT2); err != nil {
 			b.Error(err)
 		}
@@ -106,10 +108,12 @@ func BenchmarkFormamTest2(b *testing.B) {
 }
 
 func BenchmarkFormTest2(b *testing.B) {
+
+	decoder := formm.NewDecoder()
+
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		test := new(BenchFormamSchema)
-		decoder := formm.NewDecoder();
 		if err := decoder.Decode(test, valFormT2); err != nil {
 			b.Error(err)
 		}


### PR DESCRIPTION
Updated gorilla/schema and go-playground/form to be used as a single instance as indicated in README's.

```go
// Set a Decoder instance as a package global, because it caches 
// meta-data about structs, and an instance can be shared safely.
var decoder = schema.NewDecoder()
```

```go
// use a single instance of Decoder, it caches struct info
var decoder *form.Decoder
```