### PR TITLE
help update verbiage in README + Update tests for equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ BenchmarkFormTestSIMPLE-8      	  200000	      7390 ns/op	    1832 B/op	      35
 BenchmarkJSONTestSIMPLE-8      	  200000	      9728 ns/op	     848 B/op	      17 allocs/op
 ```
 
-formam is three times more fast than [ajg/form](https://github.com/ajg/form), two times more fast than [gorilla/schema](https://github.com/gorilla/schema), very slightly more slowly than [go-playground/form](https://github.com/go-playground/form), and equal than [built-in/json](http://golang.org/pkg/encoding/json/).
-[go-playground/form](https://github.com/go-playground/form) is the that less allocations does.
+formam is three times faster than [ajg/form](https://github.com/ajg/form), two times faster than [gorilla/schema](https://github.com/gorilla/schema), slightly more slowly than [go-playground/form](https://github.com/go-playground/form), and faster than [built-in/json](http://golang.org/pkg/encoding/json/).
+[go-playground/form](https://github.com/go-playground/form) has the least allocations.
 
 ### MEDIUM
 
@@ -36,7 +36,7 @@ BenchmarkJSONTestMEDIUM-8      	  100000	     16878 ns/op	    1696 B/op	      32
 ```
 
 formam is the fastest.
-[ajg/form](https://github.com/ajg/form) is that less allocations does.
+[ajg/form](https://github.com/ajg/form) has the least allocations.
 
 ### COMPLEX
 
@@ -45,5 +45,4 @@ BenchmarkFormamTestCOMPLEX-8   	    5000	    307747 ns/op	   41058 B/op	    2062
 BenchmarkFormTestCOMPLEX-8     	    2000	    572936 ns/op	  107142 B/op	    2108 allocs/op
 ```
 
-formam is the fastest (two times fastest than [go-playground/form](https://github.com/go-playground/form)).
-formam is that less allocations does.
+formam is the fastest and has the least allocations.

--- a/formam_2_test.go
+++ b/formam_2_test.go
@@ -21,7 +21,7 @@ type Medium struct {
 			Name string
 		}
 	}
-	String string `formam:"string" json:"string"`
+	String string `form:"string" formam:"string" json:"string"`
 	Slice  []int
 	Map    map[string][]string
 	Bool   bool
@@ -29,38 +29,8 @@ type Medium struct {
 	Anonymous
 }
 
-type Medium2 struct {
-	Nest struct {
-		Children []struct {
-			ID   string
-			Name string
-		}
-	}
-	String string `form:"string"`
-	Slice  []int
-	Map    map[string][]string
-	Int    int `form:"int"`
-	Bool   bool
-	Anonymous
-}
-
 var (
 	valuesFormamT1 = url.Values{
-		"Nest.Children[0].ID":   []string{"monoculum_id"},
-		"Nest.Children[0].Name": []string{"Monoculum"},
-		"Map[es_Es][0]":          []string{"javier"},
-		"Map[es_Es][1]":          []string{"javier"},
-		"Map[es_Es][2]":          []string{"javier"},
-		"Map[es_Es][3]":          []string{"javier"},
-		"Map[es_Es][4]":          []string{"javier"},
-		"Map[es_Es][5]":          []string{"javier"},
-		"string":                []string{"golang is very fun"},
-		"Slice[0]":              []string{"1"},
-		"Slice[1]":              []string{"2"},
-		"int":                   []string{"1"},
-		"Bool":                  []string{"true"},
-	}
-	valuesFormT1 = url.Values{
 		"Nest.Children[0].ID":   []string{"monoculum_id"},
 		"Nest.Children[0].Name": []string{"Monoculum"},
 		"Map[es_Es][0]":         []string{"javier"},
@@ -72,7 +42,7 @@ var (
 		"string":                []string{"golang is very fun"},
 		"Slice[0]":              []string{"1"},
 		"Slice[1]":              []string{"2"},
-		"int":                   []string{"1"},
+		"Ptr":                   []string{"ptr string"},
 		"Bool":                  []string{"true"},
 	}
 	valuesAJGFormT1 = url.Values{
@@ -87,7 +57,7 @@ var (
 		"string":               []string{"golang is very fun"},
 		"Slice.0":              []string{"1"},
 		"Slice.1":              []string{"2"},
-		"int":                  []string{"1"},
+		"Ptr":                  []string{"ptr string"},
 		"Bool":                 []string{"true"},
 	}
 	valuesJSONT1 = `
@@ -99,7 +69,7 @@ var (
 		"string": "golang is very fun",
 		"Map": {"es_Es": ["javier", "javier", "javier", "javier", "javier", "javier"]},
 		"Slice": [1, 2],
-		"int": 20,
+		"Ptr": "ptr string",
 		"Bool": true
 	}
 	`
@@ -108,7 +78,7 @@ var (
 func BenchmarkAJGFormTestMEDIUM(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		ne := new(Medium2)
+		ne := new(Medium)
 		if err := form.DecodeValues(ne, valuesAJGFormT1); err != nil {
 			b.Error(err)
 		}
@@ -130,7 +100,7 @@ func BenchmarkFormTestMEDIUM(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		test := new(Medium)
-		if err := decoder.Decode(test, valuesFormT1); err != nil {
+		if err := decoder.Decode(test, valuesFormamT1); err != nil {
 			b.Error(err)
 		}
 	}

--- a/formam_3_test.go
+++ b/formam_3_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	//"github.com/ajg/form"
+	"time"
+
 	formm "github.com/go-playground/form"
 	"github.com/monoculum/formam"
-	"time"
 )
 
 type Location struct {
@@ -225,6 +226,141 @@ var (
 		"Scores.Scores[3].Score": []string{"2"},
 		"Scores.Scores[3].Date":  []string{"2013-01-02"},
 	}
+
+	valuesFormT3 = url.Values{
+		// id
+		"ID": []string{"spirited-away"},
+
+		// type
+		"Type": []string{"film"},
+
+		// title
+		// title > es
+		// title > es > ES
+		"Titles[es][ES].Locale.Country":  []string{"Spain"},
+		"Titles[es][ES].Locale.Language": []string{"spanish"},
+		"Titles[es][ES].Value":           []string{"El viaje de Chihiro"},
+		// title > es > MX
+		"Titles[es][MX].Locale.Country":  []string{"Mexico"},
+		"Titles[es][MX].Locale.Language": []string{"spanish"},
+		"Titles[es][MX].Value":           []string{"El viaje de Chihiro"},
+		// title > es > AR
+		"Titles[es][AR].Locale.Country":  []string{"Argentina"},
+		"Titles[es][AR].Locale.Language": []string{"spanish"},
+		"Titles[es][AR].Value":           []string{"El viaje de Chihiro"},
+		// title > en
+		// title > en > US
+		"Titles[en][US].Locale.Country":  []string{"United States"},
+		"Titles[en][US].Locale.Language": []string{"english"},
+		"Titles[en][US].Value":           []string{"Spirited Away"},
+		// title > en > GB
+		"Titles[en][GB].Locale.Country":  []string{"United Kingdom"},
+		"Titles[en][GB].Locale.Language": []string{"english"},
+		"Titles[en][GB].Value":           []string{"Spirited Away"},
+		// title > fr
+		// title > fr > FR
+		"Titles[fr][FR].Locale.Country":  []string{"France"},
+		"Titles[fr][FR].Locale.Language": []string{"french"},
+		"Titles[fr][FR].Value":           []string{"Le voyage de Chihiro"},
+		// title > fr > CA
+		"Titles[fr][CA].Locale.Country":  []string{"Canada"},
+		"Titles[fr][CA].Locale.Language": []string{"french"},
+		"Titles[fr][CA].Value":           []string{"Le voyage de Chihiro"},
+		// title > de
+		// title > de > DE
+		"Titles[de][DE].Locale.Country":  []string{"Germany"},
+		"Titles[de][DE].Locale.Language": []string{"german"},
+		"Titles[de][DE].Value":           []string{"Chihiros Reise ins Zauberland"},
+		// title > ja
+		// title > ja > JA
+		"Titles[ja][JA].Locale.Country":  []string{"Japan"},
+		"Titles[ja][JA].Locale.Language": []string{"japanese"},
+		"Titles[ja][JA].Value":           []string{"Sen to Chihiro no kamikakushi"},
+
+		// year
+		"Year": []string{"2001"},
+
+		// tags
+		"Tags[0].ID":             []string{"cult"},
+		"Tags[0].Name[en].Value": []string{"Cult"},
+		"Tags[1].ID":             []string{"adventure"},
+		"Tags[1].Name[en].Value": []string{"Adventure"},
+		"Tags[2].ID":             []string{"drama"},
+		"Tags[2].Name[en].Value": []string{"Drama"},
+		"Tags[3].ID":             []string{"comedy"},
+		"Tags[3].Name[en].Value": []string{"Comedy"},
+		"Tags[4].ID":             []string{"mistery"},
+		"Tags[4].Name[en].Value": []string{"Mistery"},
+		"Tags[5].ID":             []string{"family"},
+		"Tags[5].Name[en].Value": []string{"Family"},
+
+		// moods
+		"Moods[0].ID":             []string{"cult"},
+		"Moods[0].Name[en].Value": []string{"Cult"},
+		"Moods[1].ID":             []string{"adventure"},
+		"Moods[1].Name[en].Value": []string{"Adventure"},
+		"Moods[2].ID":             []string{"drama"},
+		"Moods[2].Name[en].Value": []string{"Drama"},
+		"Moods[3].ID":             []string{"comedy"},
+		"Moods[3].Name[en].Value": []string{"Comedy"},
+		"Moods[4].ID":             []string{"mistery"},
+		"Moods[4].Name[en].Value": []string{"Mistery"},
+		"Moods[5].ID":             []string{"family"},
+		"Moods[5].Name[en].Value": []string{"Family"},
+
+		// websites
+		"Websites": []string{"cult", "adventure", "drama", "comedy", "mistery", "family"},
+
+		// release
+		// release > 0
+		"Release[0].Date":                      []string{"2001-01-02T00:00:00Z"},
+		"Release[0].Cinema.ID":                 []string{"kodak-theatrical"},
+		"Release[0].Cinema.Name":               []string{"Kodak Theatrical"},
+		"Release[0].Cinema.Location.Latitude":  []string{"121342"},
+		"Release[0].Cinema.Location.Longitude": []string{"122323"},
+		// release > 1
+		"Release[1].Date":                      []string{"2002-11-02T00:00:00Z"},
+		"Release[1].Cinema.ID":                 []string{"victor-theatrical"},
+		"Release[1].Cinema.Name":               []string{"Victor Theatrical"},
+		"Release[1].Cinema.Location.Latitude":  []string{"121342"},
+		"Release[1].Cinema.Location.Longitude": []string{"122323"},
+		// release > 2
+		"Release[2].Date":                      []string{"2002-09-02T00:00:00Z"},
+		"Release[2].Cinema.ID":                 []string{"alaska-theatrical"},
+		"Release[2].Cinema.Name":               []string{"alaska Theatrical"},
+		"Release[2].Cinema.Location.Latitude":  []string{"121342"},
+		"Release[2].Cinema.Location.Longitude": []string{"122323"},
+
+		// remake
+		"Remake.ID": []string{"taxi-driver"},
+
+		// synopsis
+		"Synopsis[en].Language": []string{"english"},
+		"Synopsis[en].Value":    []string{"During her family's move to the suburbs, a sullen 10-year-old girl wanders into a world ruled by gods, witches, and spirits, and where humans are changed into beasts."},
+		"Synopsis[es].Language": []string{"spanish"},
+		"Synopsis[es].Value":    []string{"Chihiro es una niña de diez años que viaja en coche con sus padres. Después de atravesar un túnel, llegan a un mundo fantástico, en el que no hay lugar para los seres humanos, sólo para los dioses de primera y segunda clase. Cuando descubre que sus padres han sido convertidos en cerdos, Chihiro se siente muy sola y asustada"},
+
+		// scores
+		"Scores.Total":   []string{"94315"},
+		"Scores.Average": []string{"8.1"},
+		// scores > scores
+		// scores > scores > 0
+		"Scores.Scores[0].User":  []string{"dashaus"},
+		"Scores.Scores[0].Score": []string{"9"},
+		"Scores.Scores[0].Date":  []string{"2016-01-02T00:00:00Z"},
+		// scores > scores > 1
+		"Scores.Scores[1].User":  []string{"tupac"},
+		"Scores.Scores[1].Score": []string{"8"},
+		"Scores.Scores[1].Date":  []string{"2003-01-02T00:00:00Z"},
+		// scores > scores > 2
+		"Scores.Scores[2].User":  []string{"ken-thompson"},
+		"Scores.Scores[2].Score": []string{"10"},
+		"Scores.Scores[2].Date":  []string{"2015-01-02T00:00:00Z"},
+		// scores > scores > 3
+		"Scores.Scores[3].User":  []string{"buuzz-lightyearz"},
+		"Scores.Scores[3].Score": []string{"2"},
+		"Scores.Scores[3].Date":  []string{"2013-01-02T00:00:00Z"},
+	}
 )
 
 /*
@@ -250,14 +386,13 @@ func BenchmarkFormamTestCOMPLEX(b *testing.B) {
 }
 
 func BenchmarkFormTestCOMPLEX(b *testing.B) {
+
 	decoder := formm.NewDecoder()
-	decoder.RegisterCustomTypeFunc(func(vals []string) (interface{}, error) {
-		return time.Parse("2006-01-02", vals[0])
-	}, time.Time{})
+
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		test := new(Film)
-		if err := decoder.Decode(test, valuesFormamT3); err != nil {
+		if err := decoder.Decode(test, valuesFormT3); err != nil {
 			b.Error(err)
 		}
 	}


### PR DESCRIPTION
- Updated README verbiage, for a little better english.
- Updated some of the tests as they were not processing the same values.
- Updated test3 to compare native parsing of time.Time, rather than one library parsing natively and another using a custom function which has overhead for any library.

I'll leave it up to you to re-run the benchmarks.
